### PR TITLE
docs: add Google Antigravity configuration to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,18 +57,31 @@ Example of config that should work in most MCP clients:
 
 ```json
 {
-"servers": {
+	"servers": {
 		"powerbi-modeling-mcp": {
 			"type": "stdio",
 			"command": "C:\\MCPServers\\PowerBIModelingMCP\\extension\\server\\powerbi-modeling-mcp.exe",
-			"args": [
-				"--start"                
-			],
-			"env": {}			
+			"args": ["--start"],
+			"env": {}
 		}
 	}
 }
 ```
+
+Google Antigravity config:
+
+```json
+{
+	"mcpServers": {
+		"powerbi-modeling-mcp": {
+			"type": "stdio",
+			"command": "C:\\MCPServers\\PowerBIModelingMCP\\extension\\server\\powerbi-modeling-mcp.exe",
+			"args": ["--start"],
+			"timeout": 120000
+		}
+	}
+}
+```	
 
 ## 🚀 Get started
 


### PR DESCRIPTION
This PR adds a configuration example for Google Antigravity IDE users who want to use the Power BI Modeling MCP Server.

### **Why this change?**
Google Antigravity IDE uses the "mcpServers" key in its mcp_config.json configuration file, which differs from the generic MCP client format that uses "servers". This addition provides Antigravity users with a copy-paste ready configuration.

### **Reference**

- [Google Antigravity MCP Documentation](https://antigravity.google/docs/mcp) - Antigravity's MCP configuration uses the mcp_config.json file with mcpServers as the root key
- Configuration verified working with the local Power BI Modeling MCP server


### Changes

- Added Google Antigravity-specific configuration example in the Manual Install section
- Standardized JSON formatting for consistency across both config examples