### PR TITLE
docs: add WSL manual download setup note

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,34 @@ Example of config that should work in most MCP clients:
 }
 ```
 
+**Using a manual download from WSL**
+
+If your MCP client runs inside WSL and you need to use the manually downloaded
+Windows executable, extract the VSIX to a Windows path such as
+`C:\MCPServers\PowerBIModelingMCP` and start the executable from a Windows
+working directory. A small wrapper script keeps the process from inheriting a
+Linux working directory such as `/home/user`:
+
+```bash
+#!/bin/bash
+cd /mnt/c
+exec /mnt/c/MCPServers/PowerBIModelingMCP/extension/server/powerbi-modeling-mcp.exe --start
+```
+
+Register the wrapper script as the MCP command instead of registering the
+`.exe` directly:
+
+```json
+{
+	"powerbi-modeling-mcp": {
+		"type": "stdio",
+		"command": "/path/to/powerbi-mcp-wrapper.sh",
+		"args": [],
+		"env": {}
+	}
+}
+```
+
 ## 🚀 Get started
 
 **First, you must connect to a Power BI semantic model**, which can reside in Power BI Desktop, Fabric workspace or in Power BI Project (PBIP) files.


### PR DESCRIPTION
## Summary
- Documents the WSL-specific setup needed when a WSL-based MCP client launches the manually downloaded Windows executable.
- Adds a small wrapper-script example that switches to a Windows working directory before starting `powerbi-modeling-mcp.exe`.
- Keeps the guidance scoped to manual downloads so the existing NPX option remains the simpler path for most users.

## Value
This addresses the setup gap reported in #64 and gives WSL users a concrete configuration that avoids silent startup timeouts caused by inheriting a Linux working directory.

## Validation
- Read the README manual install instructions and troubleshooting guide.
- Checked for duplicate PRs for #64 / WSL setup guidance.
- Ran `git diff --check`.

## Documentation
- Updated `README.md` only.

## Checks not run
- Did not run the MCP server from WSL locally; this is a documentation-only change and the current environment is Windows PowerShell.

Fixes #64